### PR TITLE
#16 - Keep track of time when in Interrupted, Finished or Refreshed state

### DIFF
--- a/src/Notadesigner.Approximato.Core/PomodoroService.cs
+++ b/src/Notadesigner.Approximato.Core/PomodoroService.cs
@@ -278,22 +278,7 @@ namespace Notadesigner.Approximato.Core
 
         private async Task RunRefreshedAsync(CancellationToken cancellationToken)
         {
-            if (_settingsFactory().LenientMode)
-            {
-                var total = _settingsFactory().ShortBreakDuration;
-                var elapsed = _elapsedDuration;
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    _timerChannel.Writer.TryWrite(new TimerEvent(elapsed, total));
-
-                    await Task.Delay(UnitIncrement, cancellationToken);
-                    elapsed = elapsed.Add(UnitIncrement);
-                }
-            }
-            else
-            {
-                await _stateMachine.FireAsync(TimerTrigger.Continue);
-            }
+            await _stateMachine.FireAsync(TimerTrigger.Continue);
         }
 
         private async Task RunStoppedAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Removed the lenient mode when the timer transitions into the refreshed state. Refer the comment at https://github.com/pranavnegandhi/Approximato/issues/16#issuecomment-1623773000 for a detailed explanation.