### PR TITLE
Synchronised access to the state machine used by the GUI to prevent attempts at invalid state transitions

### DIFF
--- a/src/Notadesigner.Approximato.Core/Properties/AssemblyInfo.cs
+++ b/src/Notadesigner.Approximato.Core/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1b1a39bc-5791-43a7-9eb9-4dcfbadaab9f")]
 [assembly: AssemblyTitle("Approximato Core – Time Manager for Windows")]
-[assembly: AssemblyVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
 [assembly: AssemblyInformationalVersion("1.4.2.0")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]

--- a/src/Notadesigner.Approximato.Core/StateHost.cs
+++ b/src/Notadesigner.Approximato.Core/StateHost.cs
@@ -1,306 +1,396 @@
 ﻿using Notadesigner.Approximato.Messaging.Contracts;
+using Serilog;
 using Stateless;
 
-namespace Notadesigner.Approximato.Core
+namespace Notadesigner.Approximato.Core;
+
+public class StateHost : IEventHandler<UIEvent>
 {
-    public class StateHost : IEventHandler<UIEvent>
+    public event EventHandler<UIEvent>? EventReceived;
+
+    private static readonly TimeSpan UnitIncrement = TimeSpan.FromSeconds(1);
+
+    private readonly Func<StateHostSettings> _settingsFactory;
+
+    private readonly StateMachine<TimerState, TimerTrigger> _stateMachine = new(TimerState.Begin);
+
+    private readonly IProducer<TransitionEvent> _transitionproducer;
+
+    private readonly IProducer<TimerEvent> _timerProducer;
+
+    private TimeSpan _elapsedDuration = TimeSpan.Zero;
+
+    private int _focusCounter = 0;
+
+    private CancellationTokenSource? _activeCts;
+
+    private readonly ILogger _logger = Log.ForContext<StateHost>();
+
+    public StateHost(Func<StateHostSettings> settingsFactory, IProducer<TransitionEvent> transitionProducer, IProducer<TimerEvent> timerProducer)
     {
-        public event EventHandler<UIEvent>? EventReceived;
+        _settingsFactory = settingsFactory;
+        _transitionproducer = transitionProducer;
+        _timerProducer = timerProducer;
 
-        private static readonly TimeSpan UnitIncrement = TimeSpan.FromSeconds(1);
+        ConfigureStates(_stateMachine);
+        _stateMachine.FireAsync(TimerTrigger.Reset);
+    }
 
-        private readonly Func<StateHostSettings> _settingsFactory;
+    public async ValueTask HandleAsync(UIEvent @event, CancellationToken token = default) =>
+        await _stateMachine.FireAsync(@event.Trigger);
 
-        private readonly StateMachine<TimerState, TimerTrigger> _stateMachine = new(TimerState.Begin);
+    private void ConfigureStates(StateMachine<TimerState, TimerTrigger> stateMachine)
+    {
+        stateMachine.OnUnhandledTrigger((state, trigger) => { });
+        stateMachine.OnTransitioned(transition => { });
 
-        private readonly IProducer<TransitionEvent> _transitionproducer;
-
-        private readonly IProducer<TimerEvent> _timerProducer;
-
-        private TimeSpan _elapsedDuration = TimeSpan.Zero;
-
-        private int _focusCounter = 0;
-
-        private CancellationTokenSource? _activeCts;
-
-        public StateHost(Func<StateHostSettings> settingsFactory, IProducer<TransitionEvent> transitionProducer, IProducer<TimerEvent> timerProducer)
-        {
-            _settingsFactory = settingsFactory;
-            _transitionproducer = transitionProducer;
-            _timerProducer = timerProducer;
-
-            ConfigureStates(_stateMachine);
-            _stateMachine.FireAsync(TimerTrigger.Reset);
-        }
-
-        public async ValueTask HandleAsync(UIEvent @event, CancellationToken token = default) =>
-            await _stateMachine.FireAsync(@event.Trigger);
-
-        private void ConfigureStates(StateMachine<TimerState, TimerTrigger> stateMachine)
-        {
-            stateMachine.OnUnhandledTrigger((state, trigger) => { });
-            stateMachine.OnTransitioned(transition => { });
-
-            stateMachine.Configure(TimerState.Abandoned)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Abandoned, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-                })
-                .Permit(TimerTrigger.Reset, TimerState.Begin);
-
-            stateMachine.Configure(TimerState.Begin)
-                .OnEntryAsync(async () =>
-                {
-                    _focusCounter = 0;
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Begin, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-                })
-                .Permit(TimerTrigger.Focus, TimerState.Focused)
-                .PermitReentry(TimerTrigger.Reset); /// Explicitly allowed to easily set state on application startup
-
-            stateMachine.Configure(TimerState.End)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.End, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-                })
-                .Permit(TimerTrigger.Reset, TimerState.Begin);
-
-            stateMachine.Configure(TimerState.Finished)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Finished, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunFinishedAsync(_activeCts.Token);
-                })
-                .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
-                .PermitIf(TimerTrigger.Continue, TimerState.Relaxed, () => _focusCounter < _settingsFactory().MaximumRounds)
-                .PermitIf(TimerTrigger.Continue, TimerState.Stopped, () => _focusCounter >= _settingsFactory().MaximumRounds);
-
-            stateMachine.Configure(TimerState.Focused)
-                .OnEntryFromAsync(TimerTrigger.Focus, async () =>
-                {
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Focused, ++_focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunFocusedAsync(_activeCts.Token);
-                })
-                .OnEntryFromAsync(TimerTrigger.Resume, async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    /// Don't increment focusCounter when resuming an interrupted session
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Focused, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunFocusedAsync(_activeCts.Token);
-                })
-                .OnEntryFromAsync(TimerTrigger.Continue, async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Focused, ++_focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunFocusedAsync(_activeCts.Token);
-                })
-                .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
-                .Permit(TimerTrigger.Interrupt, TimerState.Interrupted)
-                .Permit(TimerTrigger.Timeout, TimerState.Finished);
-
-            stateMachine.Configure(TimerState.Interrupted)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Interrupted, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunInterruptedAsync(_activeCts.Token);
-                })
-                .Permit(TimerTrigger.Resume, TimerState.Focused);
-
-            stateMachine.Configure(TimerState.Refreshed)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Refreshed, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    await _stateMachine.FireAsync(TimerTrigger.Continue);
-                })
-                .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
-                .Permit(TimerTrigger.Continue, TimerState.Focused);
-
-            stateMachine.Configure(TimerState.Relaxed)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Relaxed, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunRelaxedAsync(_activeCts.Token);
-                })
-                .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
-                .Permit(TimerTrigger.Timeout, TimerState.Refreshed);
-
-            stateMachine.Configure(TimerState.Stopped)
-                .OnEntryAsync(async () =>
-                {
-                    /// Dispose the cancellationTokenSource
-                    /// as it is no longer needed
-                    _activeCts?.Cancel();
-                    _activeCts?.Dispose();
-                    _activeCts = null;
-
-                    var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Stopped, _focusCounter));
-                    await _transitionproducer.PublishAsync(@event);
-
-                    _activeCts = new();
-                    var _ = RunStoppedAsync(_activeCts.Token);
-                })
-                .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
-                .Permit(TimerTrigger.Timeout, TimerState.End);
-        }
-
-        private async Task RunFocusedAsync(CancellationToken cancellationToken)
-        {
-            var delay = _settingsFactory().FocusDuration;
-            var elapsed = TimeSpan.Zero;
-            while (elapsed <= delay && !cancellationToken.IsCancellationRequested)
+        stateMachine.Configure(TimerState.Abandoned)
+            .OnEntryAsync(async () =>
             {
-                var @event = new Event<TimerEvent>(new TimerEvent(elapsed, delay));
-                await _timerProducer.PublishAsync(@event, cancellationToken);
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
 
-                await Task.Delay(UnitIncrement, cancellationToken);
-                elapsed = elapsed.Add(UnitIncrement);
-            }
-
-            if (elapsed >= delay)
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Abandoned, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+            })
+            .OnExitAsync(transition =>
             {
-                _elapsedDuration = elapsed;
-                await _stateMachine.FireAsync(TimerTrigger.Timeout);
-            }
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Reset, TimerState.Begin);
+
+        stateMachine.Configure(TimerState.Begin)
+            .OnEntryAsync(async () =>
+            {
+                _focusCounter = 0;
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Begin, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Focus, TimerState.Focused)
+            .PermitReentry(TimerTrigger.Reset); /// Explicitly allowed to easily set state on application startup
+
+        stateMachine.Configure(TimerState.End)
+            .OnEntryAsync(async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.End, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Reset, TimerState.Begin);
+
+        stateMachine.Configure(TimerState.Finished)
+            .OnEntryAsync(async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Finished, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunFinishedAsync(_activeCts.Token);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
+            .PermitIf(TimerTrigger.Continue, TimerState.Relaxed, () => _focusCounter < _settingsFactory().MaximumRounds)
+            .PermitIf(TimerTrigger.Continue, TimerState.Stopped, () => _focusCounter >= _settingsFactory().MaximumRounds);
+
+        stateMachine.Configure(TimerState.Focused)
+            .OnEntryFromAsync(TimerTrigger.Focus, async () =>
+            {
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Focused, ++_focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunFocusedAsync(_activeCts.Token);
+            })
+            .OnEntryFromAsync(TimerTrigger.Resume, async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                /// Don't increment focusCounter when resuming an interrupted session
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Focused, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunFocusedAsync(_activeCts.Token);
+            })
+            .OnEntryFromAsync(TimerTrigger.Continue, async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Focused, ++_focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunFocusedAsync(_activeCts.Token);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
+            .Permit(TimerTrigger.Interrupt, TimerState.Interrupted)
+            .Permit(TimerTrigger.Timeout, TimerState.Finished);
+
+        stateMachine.Configure(TimerState.Interrupted)
+            .OnEntryAsync(async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Interrupted, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunInterruptedAsync(_activeCts.Token);
+            })
+            .Permit(TimerTrigger.Resume, TimerState.Focused);
+
+        stateMachine.Configure(TimerState.Refreshed)
+            .OnEntryAsync(async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Refreshed, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                await _stateMachine.FireAsync(TimerTrigger.Continue);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
+            .Permit(TimerTrigger.Continue, TimerState.Focused);
+
+        stateMachine.Configure(TimerState.Relaxed)
+            .OnEntryAsync(async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Relaxed, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunRelaxedAsync(_activeCts.Token);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
+            .Permit(TimerTrigger.Timeout, TimerState.Refreshed);
+
+        stateMachine.Configure(TimerState.Stopped)
+            .OnEntryAsync(async () =>
+            {
+                /// Dispose the cancellationTokenSource
+                /// as it is no longer needed
+                _activeCts?.Cancel();
+                _activeCts?.Dispose();
+                _activeCts = null;
+
+                var @event = new Event<TransitionEvent>(new TransitionEvent(TimerState.Stopped, _focusCounter));
+                await _transitionproducer.PublishAsync(@event);
+
+                _activeCts = new();
+                var _ = RunStoppedAsync(_activeCts.Token);
+            })
+            .OnExitAsync(transition =>
+            {
+                _logger.Debug("{Module} | {Source} -{Transition}-> {Destination} {Counter}",
+                    nameof(StateHost),
+                    transition.Source,
+                    nameof(StateMachine<TimerState, TimerTrigger>.StateConfiguration.OnExitAsync),
+                    transition.Destination,
+                    _focusCounter);
+
+                return Task.CompletedTask;
+            })
+            .Permit(TimerTrigger.Abandon, TimerState.Abandoned)
+            .Permit(TimerTrigger.Timeout, TimerState.End);
+    }
+
+    private async Task RunFocusedAsync(CancellationToken cancellationToken)
+    {
+        var delay = _settingsFactory().FocusDuration;
+        var elapsed = TimeSpan.Zero;
+        while (elapsed <= delay && !cancellationToken.IsCancellationRequested)
+        {
+            var @event = new Event<TimerEvent>(new TimerEvent(elapsed, delay));
+            await _timerProducer.PublishAsync(@event, cancellationToken);
+
+            await Task.Delay(UnitIncrement, cancellationToken);
+            elapsed = elapsed.Add(UnitIncrement);
         }
 
-        private async Task RunInterruptedAsync(CancellationToken cancellationToken)
+        if (elapsed >= delay)
         {
-            var elapsed = TimeSpan.Zero;
+            _elapsedDuration = elapsed;
+            await _stateMachine.FireAsync(TimerTrigger.Timeout);
+        }
+    }
+
+    private async Task RunInterruptedAsync(CancellationToken cancellationToken)
+    {
+        var elapsed = TimeSpan.Zero;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var @event = new Event<TimerEvent>(new TimerEvent(elapsed, TimeSpan.FromMinutes(59)));
+            await _timerProducer.PublishAsync(@event, cancellationToken);
+
+            await Task.Delay(UnitIncrement, cancellationToken);
+            elapsed = elapsed.Add(UnitIncrement);
+        }
+    }
+
+    private async Task RunFinishedAsync(CancellationToken cancellationToken)
+    {
+        if (_settingsFactory().LenientMode)
+        {
+            var total = _settingsFactory().FocusDuration;
+            var elapsed = _elapsedDuration;
             while (!cancellationToken.IsCancellationRequested)
             {
-                var @event = new Event<TimerEvent>(new TimerEvent(elapsed, TimeSpan.FromMinutes(59)));
+                var @event = new Event<TimerEvent>(new TimerEvent(elapsed, total));
                 await _timerProducer.PublishAsync(@event, cancellationToken);
 
                 await Task.Delay(UnitIncrement, cancellationToken);
                 elapsed = elapsed.Add(UnitIncrement);
             }
         }
-
-        private async Task RunFinishedAsync(CancellationToken cancellationToken)
+        else
         {
-            if (_settingsFactory().LenientMode)
-            {
-                var total = _settingsFactory().FocusDuration;
-                var elapsed = _elapsedDuration;
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    var @event = new Event<TimerEvent>(new TimerEvent(elapsed, total));
-                    await _timerProducer.PublishAsync(@event, cancellationToken);
+            await _stateMachine.FireAsync(TimerTrigger.Continue);
+        }
+    }
 
-                    await Task.Delay(UnitIncrement, cancellationToken);
-                    elapsed = elapsed.Add(UnitIncrement);
-                }
-            }
-            else
-            {
-                await _stateMachine.FireAsync(TimerTrigger.Continue);
-            }
+    private async Task RunRelaxedAsync(CancellationToken cancellationToken)
+    {
+        var delay = _settingsFactory().ShortBreakDuration;
+        var elapsed = TimeSpan.Zero;
+        while (elapsed <= delay && !cancellationToken.IsCancellationRequested)
+        {
+            var @event = new Event<TimerEvent>(new TimerEvent(elapsed, delay));
+            await _timerProducer.PublishAsync(@event, cancellationToken);
+
+            await Task.Delay(UnitIncrement, cancellationToken);
+            elapsed = elapsed.Add(UnitIncrement);
         }
 
-        private async Task RunRelaxedAsync(CancellationToken cancellationToken)
+        if (elapsed >= delay)
         {
-            var delay = _settingsFactory().ShortBreakDuration;
-            var elapsed = TimeSpan.Zero;
-            while (elapsed <= delay && !cancellationToken.IsCancellationRequested)
-            {
-                var @event = new Event<TimerEvent>(new TimerEvent(elapsed, delay));
-                await _timerProducer.PublishAsync(@event, cancellationToken);
+            _elapsedDuration = elapsed;
+            await _stateMachine.FireAsync(TimerTrigger.Timeout);
+        }
+    }
 
-                await Task.Delay(UnitIncrement, cancellationToken);
-                elapsed = elapsed.Add(UnitIncrement);
-            }
+    private async Task RunStoppedAsync(CancellationToken cancellationToken)
+    {
+        var delay = _settingsFactory().LongBreakDuration;
+        var elapsed = TimeSpan.Zero;
+        while (elapsed <= delay && !cancellationToken.IsCancellationRequested)
+        {
+            var @event = new Event<TimerEvent>(new TimerEvent(elapsed, delay));
+            await _timerProducer.PublishAsync(@event, cancellationToken);
 
-            if (elapsed >= delay)
-            {
-                _elapsedDuration = elapsed;
-                await _stateMachine.FireAsync(TimerTrigger.Timeout);
-            }
+            await Task.Delay(UnitIncrement, cancellationToken);
+            elapsed = elapsed.Add(UnitIncrement);
         }
 
-        private async Task RunStoppedAsync(CancellationToken cancellationToken)
+        if (elapsed >= delay)
         {
-            var delay = _settingsFactory().LongBreakDuration;
-            var elapsed = TimeSpan.Zero;
-            while (elapsed <= delay && !cancellationToken.IsCancellationRequested)
-            {
-                var @event = new Event<TimerEvent>(new TimerEvent(elapsed, delay));
-                await _timerProducer.PublishAsync(@event, cancellationToken);
-
-                await Task.Delay(UnitIncrement, cancellationToken);
-                elapsed = elapsed.Add(UnitIncrement);
-            }
-
-            if (elapsed >= delay)
-            {
-                await _stateMachine.FireAsync(TimerTrigger.Timeout);
-            }
+            await _stateMachine.FireAsync(TimerTrigger.Timeout);
         }
     }
 }

--- a/src/Notadesigner.Approximato.Core/UIEvent.cs
+++ b/src/Notadesigner.Approximato.Core/UIEvent.cs
@@ -8,5 +8,7 @@
         }
 
         public TimerTrigger Trigger { get; init; }
+
+        public override string ToString() => $"{Trigger}";
     }
 }

--- a/src/Notadesigner.Approximato.Data/Properties/AssemblyInfo.cs
+++ b/src/Notadesigner.Approximato.Data/Properties/AssemblyInfo.cs
@@ -16,8 +16,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("09e7d5cc-9a10-4ae3-a37e-435cad138f68")]
 [assembly: AssemblyTitle("Approximato Data – Time Manager for Windows")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyInformationalVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyInformationalVersion("1.4.3.0")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("notadesigner.com")]

--- a/src/Notadesigner.Approximato.Messaging/Impl/TransientEventBusProducer.cs
+++ b/src/Notadesigner.Approximato.Messaging/Impl/TransientEventBusProducer.cs
@@ -1,4 +1,5 @@
 ﻿using Notadesigner.Approximato.Messaging.Contracts;
+using Serilog;
 using System.Threading.Channels;
 
 namespace Notadesigner.Approximato.Messaging.Impl
@@ -6,6 +7,8 @@ namespace Notadesigner.Approximato.Messaging.Impl
     internal sealed class TransientBusEventProducer<T>(ChannelWriter<Event<T>> bus) : IProducer<T>
     {
         private readonly ChannelWriter<Event<T>> _bus = bus;
+
+        private readonly ILogger _logger = Log.ForContext<TransientBusEventProducer<T>>();
 
         public ValueTask DisposeAsync()
         {
@@ -16,6 +19,11 @@ namespace Notadesigner.Approximato.Messaging.Impl
 
         public async ValueTask PublishAsync(Event<T> @event, CancellationToken cancellationToken = default)
         {
+            _logger.Debug("{Module} | Published {Event}",
+                nameof(TransientBusEventProducer<T>),
+                @event.Data?.ToString(),
+                @event.GetType());
+
             await _bus.WriteAsync(@event, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Notadesigner.Approximato.Messaging/Properties/AssemblyInfo.cs
+++ b/src/Notadesigner.Approximato.Messaging/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("5e6f1b4b-7ac3-4d90-a3f1-e4e972e960f4")]
 [assembly: AssemblyTitle("Approximato Messaging – Time Manager for Windows")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyInformationalVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyInformationalVersion("1.4.3.0")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("notadesigner.com")]

--- a/src/Notadesigner.Approximato.Windows/Properties/AssemblyInfo.cs
+++ b/src/Notadesigner.Approximato.Windows/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Runtime.Versioning;
 
 [assembly: Guid("15D06A35-6722-4A2E-9D78-CF5A97BA10F6")]
 [assembly: AssemblyTitle("Approximato – Time Manager for Windows")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyInformationalVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyInformationalVersion("1.4.3.0")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("notadesigner.com")]

--- a/src/Notadesigner.Approximato.Windows/appsettings.json
+++ b/src/Notadesigner.Approximato.Windows/appsettings.json
@@ -12,9 +12,17 @@
       {
         "Name": "File",
         "Args": {
-          "path": "log.clef",
+          "path": "state-transitions.clef",
           "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
           "rollingInterval": "Day"
+        }
+      }
+    ],
+    "Filter": [
+      {
+        "Name": "ByIncludingOnly",
+        "Args": {
+          "expression": "StartsWith(SourceContext, 'Notadesigner.')"
         }
       }
     ]


### PR DESCRIPTION
The state machine that maintains the current state of the GUI attempts to make invalid transitions, typically from relaxed to focused again. This is due multiple events being dispatched on the queue in quick succession (like it does when transitioning from relaxed to refreshed to focused).

This fix addresses this by synchronising access to the GUI state machine between threads / tasks. By limiting access to only one thread at a time, the semaphore ensures that transitions maintain their sequence.