### PR TITLE
Removed notification balloon which is displayed when entering focused state

### DIFF
--- a/src/Notadesigner.Approximato.Windows/GuiRunnerContext.cs
+++ b/src/Notadesigner.Approximato.Windows/GuiRunnerContext.cs
@@ -205,9 +205,6 @@ namespace Notadesigner.Approximato.Windows
             _resetMenu.Enabled = false;
             _notifyIcon.Text = null;
 
-            var message = GuiRunnerResources.FocusedEnterNotification;
-            _notifyIcon.ShowBalloonTip(500, string.Empty, message, ToolTipIcon.None);
-
             _enterSound.PlaySync();
             _tickPlayer.PlayLooping();
         }

--- a/src/Notadesigner.Approximato.Windows/Properties/GuiRunnerResources.Designer.cs
+++ b/src/Notadesigner.Approximato.Windows/Properties/GuiRunnerResources.Designer.cs
@@ -116,15 +116,6 @@ namespace Notadesigner.Approximato.Windows.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starting a focus session..
-        /// </summary>
-        internal static string FocusedEnterNotification {
-            get {
-                return ResourceManager.GetString("FocusedEnterNotification", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Less than a minute elapsed.
         /// </summary>
         internal static string LessThanOneMinuteElapsedToolTip {

--- a/src/Notadesigner.Approximato.Windows/Properties/GuiRunnerResources.resx
+++ b/src/Notadesigner.Approximato.Windows/Properties/GuiRunnerResources.resx
@@ -136,9 +136,6 @@
   <data name="EndToolTip" xml:space="preserve">
     <value>Done. Reset to begin again.</value>
   </data>
-  <data name="FocusedEnterNotification" xml:space="preserve">
-    <value>Starting a focus session.</value>
-  </data>
   <data name="LessThanOneMinuteElapsedToolTip" xml:space="preserve">
     <value>Less than a minute elapsed</value>
   </data>


### PR DESCRIPTION
The application feels a little less chatty as a result, which is probably a good thing.